### PR TITLE
Add ability to re-run tests

### DIFF
--- a/avocado_i2n/runner.py
+++ b/avocado_i2n/runner.py
@@ -46,25 +46,73 @@ class CartesianRunner(TestRunner):
     description = 'Runs tests through a Cartesian graph traversal'
 
     """running functionality"""
-    def run_test_node(self, node):
+    def run_test_node(self, node, can_retry=False):
         """
-        A wrapper around the inherited :py:meth:`run_test`.
+        Run a node once, and optionally re-run it depending on the parameters.
 
         :param node: test node to run
         :type node: :py:class:`TestNode`
+        :param bool can_retry: whether this node can be re-run
         :returns: run status of :py:meth:`run_test`
         :rtype: bool
         :raises: :py:class:`AssertionError` if the ran test node contains no objects
 
-        This is a simple wrapper to provide some default arguments
-        for simplicity of invocation.
+        The retry parameters are `retry_attempts` and `retry_stop`. The first is
+        the maximum number of retries, and the second indicates when to stop retrying.
+        The possible combinations of these values are:
+
+        - `retry_stop = error`: retry until error or a maximum of `retry_attempts` number of times
+        - `retry_stop = success`: retry until success or a maximum of `retry_attempts` number of times
+        - `retry_stop = none`: retry a maximum of `retry_attempts` number of times
+
+        Only tests with the status of pass, warning, error or failure will be retried.
+        Other statuses will be ignored and the test will run only once.
+
+        This method also works as a convenience wrapper around :py:meth:`run_test`,
+        providing some default arguments.
         """
         if node.is_objectless():
             raise AssertionError("Cannot run test nodes not using any test objects, here %s" % node)
-        # TODO: in the future we better inherit from the Runner interface in
-        # avocado.core.plugin_interfaces and implement our own test node running
-        # like most of the other runners do
-        return self.run_test(self.job, node.get_test_factory(self.job), SimpleQueue(), set())
+
+        retry_stop = node.params.get("retry_stop", "none")
+        # ignore the retry parameters for nodes that cannot be re-run (need to run at least once)
+        runs_left = 1 + node.params.get_numeric("retry_attempts", 0) if can_retry else 1
+        # do not log when the user is not using the retry feature
+        if runs_left > 1:
+            logging.debug(f"Running test with retry_stop={retry_stop} and retry_attempts={runs_left}")
+
+        assert runs_left >= 1, "retry_attempts cannot be less than zero"
+        assert retry_stop in ["none", "error", "success"], "retry_stop must be one of 'none', 'error' or 'success'"
+
+        retval = False
+        original_shortname = node.params["shortname"]
+        for r in range(runs_left):
+            # appending a suffix to retries so we can tell them appart
+            if r > 0:
+                node.params["shortname"] = f"{original_shortname}.r{r}"
+
+            # TODO: in the future we better inherit from the Runner interface in
+            # avocado.core.plugin_interfaces and implement our own test node running
+            # like most of the other runners do
+            retval = self.run_test(self.job, node.get_test_factory(self.job), SimpleQueue(), set())
+
+            test_result = next((x for x in self.result.tests if x["name"].name == node.params["shortname"]))
+            test_status = test_result["status"]
+            if test_status not in ["PASS", "WARN", "ERROR", "FAIL"]:
+                # it doesn't make sense to retry with other status
+                logging.info(f"Will not attempt to retry test with status {test_status}")
+                break
+            if retry_stop == "success" and test_status in ["PASS", "WARN"]:
+                logging.info("Stopping after first successful run")
+                break
+            if retry_stop == "error" and test_status in ["ERROR", "FAIL"]:
+                logging.info("Stopping after first failed run")
+                break
+        node.params["shortname"] = original_shortname
+        # no need to log when test was not repeated
+        if runs_left > 1:
+            logging.info(f"Finished running test {r} times")
+        return retval
 
     def run_traversal(self, graph, params):
         """
@@ -342,7 +390,7 @@ class CartesianRunner(TestRunner):
 
             else:
                 # finally, good old running of an actual test
-                self.run_test_node(test_node)
+                self.run_test_node(test_node, can_retry=True)
 
             for test_object in test_node.objects:
                 object_name = test_object.name

--- a/selftests/test_cartesian_graph.py
+++ b/selftests/test_cartesian_graph.py
@@ -37,6 +37,10 @@ class DummyTestRunning(object):
 
     def result(self):
         shortname = self.current_test_dict["shortname"]
+        # allow tests to specify the status they expect
+        if self.current_test_dict.get("test_status"):
+            self.add_test_result(shortname, self.current_test_dict["test_status"])
+            return True
         if self.expected_test_fail and "install" in self.expected_test_dict["shortname"]:
             self.add_test_result(shortname, "FAIL")
             raise exceptions.TestFail("God wanted this test to fail")
@@ -631,6 +635,188 @@ class CartesianGraphTest(unittest.TestCase):
 
         self.runner.job.config = self.config
         self.runner.run_suite(self.runner.job, test_suite)
+
+    def test_run_n_times(self):
+        """Check that the test is retried `retry_attempts` times if `retry_stop` is not specified."""
+        self.config["tests_str"] += "only tutorial1\n"
+        self.config["param_dict"]["retry_attempts"] = "4"
+        graph = self.loader.parse_object_trees(
+            self.config["param_dict"], self.config["tests_str"],
+            self.config["vm_strs"], prefix="")
+        DummyTestRunning.asserted_tests = [
+            {"shortname": r"^internal.stateless.0scan.vm1", "vms": r"^vm1$"},
+            {"shortname": r"^internal.stateless.0root.vm1", "vms": r"^vm1$"},
+            {"shortname": r"^internal.stateless.0preinstall.vm1", "vms": r"^vm1$"},
+            {"shortname": r"^original.unattended_install.cdrom.extra_cdrom_ks.default_install.aio_threads.vm1", "vms": r"^vm1$"},
+            {"shortname": r"^internal.permanent.customize.vm1", "vms": r"^vm1$"},
+            {"shortname": r"^internal.permanent.customize.vm1.*?\.r1", "vms": r"^vm1$"},
+            {"shortname": r"^internal.permanent.customize.vm1.*?\.r2", "vms": r"^vm1$"},
+            {"shortname": r"^internal.permanent.customize.vm1.*?\.r3", "vms": r"^vm1$"},
+            {"shortname": r"^internal.permanent.customize.vm1.*?\.r4", "vms": r"^vm1$"},
+            {"shortname": r"^internal.ephemeral.on_customize.vm1", "vms": r"^vm1$"},
+            {"shortname": r"^normal.nongui.quicktest.tutorial1.vm1", "vms": r"^vm1$"},
+            {"shortname": r"^normal.nongui.quicktest.tutorial1.vm1.*?\.r1", "vms": r"^vm1$"},
+            {"shortname": r"^normal.nongui.quicktest.tutorial1.vm1.*?\.r2", "vms": r"^vm1$"},
+            {"shortname": r"^normal.nongui.quicktest.tutorial1.vm1.*?\.r3", "vms": r"^vm1$"},
+            {"shortname": r"^normal.nongui.quicktest.tutorial1.vm1.*?\.r4", "vms": r"^vm1$"},
+        ]
+        DummyTestRunning.fail_switch = [False] * len(DummyTestRunning.asserted_tests)
+        self.runner.run_traversal(graph, {})
+
+    def test_last_exit_code_is_preserved(self):
+        """Check that the return value of the last run is preserved."""
+        params = {
+            "retry_stop": "none",
+            "retry_attempts": "5",
+            "shortname": "some1-random_test"
+        }
+        test_node = self._mock_test_node(params)
+        # check that all tests have been run at least this first time
+        asserted_tests = [
+            {"shortname": r"^some1-random_test$"},
+            {"shortname": r"^some1-random_test\.r1$"},
+            {"shortname": r"^some1-random_test\.r2$"},
+            {"shortname": r"^some1-random_test\.r3$"},
+            {"shortname": r"^some1-random_test\.r4$"},
+            {"shortname": r"^some1-random_test\.r5$"}
+        ]
+        fail_switch = [False] * len(asserted_tests)
+        DummyTestRunning.asserted_tests = list(asserted_tests)
+        DummyTestRunning.fail_switch = list(fail_switch)
+        status = self.runner.run_test_node(test_node, can_retry=True)
+        # all runs succeed - status must be True
+        self.assertTrue(status)
+
+        # last run fails - status must be False
+        test_node = self._mock_test_node(params)
+        DummyTestRunning.asserted_tests = list(asserted_tests)
+        DummyTestRunning.fail_switch = list(fail_switch)
+        DummyTestRunning.fail_switch[-1] = True
+        status = self.runner.run_test_node(test_node, can_retry=True)
+        self.assertFalse(status, "runner not preserving last status")
+
+        # fourth run fails - status must be True
+        test_node = self._mock_test_node(params)
+        DummyTestRunning.asserted_tests = list(asserted_tests)
+        DummyTestRunning.fail_switch = list(fail_switch)
+        DummyTestRunning.fail_switch[3] = True
+        status = self.runner.run_test_node(test_node, can_retry=True)
+        self.assertTrue(status, "runner not preserving last status")
+
+    def test_retry_on_correct_status(self):
+        """Check that certain status are ignored when retrying a test."""
+        params = {
+            "retry_stop": "none",
+            "retry_attempts": "3",
+            "shortname": "some1-random_test"
+        }
+
+        # test should not be re-run on these status
+        for s in ["SKIP", "INTERRUPTED", "CANCEL"]:
+            DummyTestRunning.asserted_tests = [{"shortname": r"^some1-random_test$"}]
+            DummyTestRunning.fail_switch = [False]
+            test_node = self._mock_test_node({ **params, "test_status": s })
+            self.runner.run_test_node(test_node, can_retry=True)
+            # assert that tests were not repeated
+            self.assertEqual(len(self.runner.result.tests), 1)
+            # also assert the correct results were registered
+            self.assertEqual([x["status"] for x in self.runner.result.tests], [s])
+            self.runner.result.tests.clear()
+
+        # test should be re-run on these status
+        for s in ["PASS", "WARN", "FAIL", "ERROR"]:
+            DummyTestRunning.asserted_tests = [
+                {"shortname": r"^some1-random_test$"},
+                {"shortname": r"^some1-random_test\.r1$"},
+                {"shortname": r"^some1-random_test\.r2$"},
+                {"shortname": r"^some1-random_test\.r3$"}
+            ]
+            DummyTestRunning.fail_switch = [False] * len(DummyTestRunning.asserted_tests)
+            test_node = self._mock_test_node({ **params, "test_status": s })
+            self.runner.run_test_node(test_node, can_retry=True)
+            # assert that tests were not repeated
+            self.assertEqual(len(self.runner.result.tests), 4)
+            # also assert the correct results were registered
+            self.assertEqual([x["status"] for x in self.runner.result.tests], [s] * 4)
+            self.runner.result.tests.clear()
+
+    def test_stop_on_status(self):
+        """Check that the `retry_stop` parameter is correctly handled by the runner."""
+        params = {
+            "retry_stop": "none",
+            "retry_attempts": "3",
+            "shortname": "some1-random_test"
+        }
+        # expect success and get success -> should run only once
+        for s in ["PASS", "WARN"]:
+            # a single test as it should not be repeated
+            DummyTestRunning.asserted_tests = [{"shortname": r"^some1-random_test$"}]
+            DummyTestRunning.fail_switch = [False]
+            new_params = { **params, "test_status": s, "retry_stop": "success" }
+            test_node = self._mock_test_node(new_params)
+            self.runner.run_test_node(test_node, can_retry=True)
+            # also assert the correct results were registered
+            self.assertEqual([x["status"] for x in self.runner.result.tests], [s])
+            self.runner.result.tests.clear()
+
+        # expect failure and get failure -> should run only once
+        for s in ["FAIL", "ERROR"]:
+            # a single test as it should not be repeated
+            DummyTestRunning.asserted_tests = [{"shortname": r"^some1-random_test$"}]
+            DummyTestRunning.fail_switch = [False]
+            new_params = { **params, "test_status": s, "retry_stop": "error" }
+            test_node = self._mock_test_node(new_params)
+            self.runner.run_test_node(test_node, can_retry=True)
+            # also assert the correct results were registered
+            self.assertEqual([x["status"] for x in self.runner.result.tests], [s])
+            self.runner.result.tests.clear()
+
+    def test_invalid_retry_stop(self):
+        """Check if an exception is thrown when retry_stop has an invalid value."""
+        params = {
+            "retry_stop": "invalid",
+            "retry_attempts": "5",
+            "shortname": "some1-random_test"
+        }
+        test_node = self._mock_test_node(params)
+        self.assertRaises(AssertionError, self.runner.run_test_node, test_node, can_retry=True)
+
+    def test_invalid_retry_attempts(self):
+        """Check if an exception is thrown when retry_attempts has an invalid value."""
+        params = {
+            "retry_stop": "none",
+            "shortname": "some1-random_test"
+        }
+        # negative values
+        with mock.patch.dict(params, { "retry_attempts": "-32" }):
+            test_node = self._mock_test_node(params)
+            self.assertRaises(AssertionError, self.runner.run_test_node, test_node, can_retry=True)
+
+        # floats
+        with mock.patch.dict(params, { "retry_attempts": "3.5" }):
+            test_node = self._mock_test_node(params)
+            self.assertRaises(ValueError, self.runner.run_test_node, test_node, can_retry=True)
+
+        # non-integers
+        with mock.patch.dict(params, { "retry_attempts": "hey" }):
+            test_node = self._mock_test_node(params)
+            self.assertRaises(ValueError, self.runner.run_test_node, test_node, can_retry=True)
+
+    def _mock_test_node(self, test_params):
+        """Create a mock of a test node to call py:function:`CartesianRunner.run_test_node` directly."""
+        test_node = mock.MagicMock()
+        # mock node params
+        params = test_params
+        test_node.params = mock.MagicMock()
+        test_node.params.__getitem__.side_effect = params.__getitem__
+        test_node.params.__setitem__.side_effect = params.__setitem__
+        test_node.params.get.side_effect = params.get
+        test_node.params.keys.side_effect = params.keys
+        test_node.params.get_numeric.side_effect = lambda _1, _2: int(test_params.get("retry_attempts", 1))
+        # mock some needed functions
+        test_node.is_objectless.side_effect = lambda: False
+        test_node.get_test_factory.side_effect = lambda _: [None, { "vt_params": test_node.params }]
+        return test_node
 
 if __name__ == '__main__':
     unittest.main()

--- a/selftests/test_intertest_setup.py
+++ b/selftests/test_intertest_setup.py
@@ -18,21 +18,33 @@ class DummyTestRunning(object):
     fail_switch = False
     asserted_tests = []
 
-    def __init__(self, node_params):
+    def __init__(self, node_params, test_results):
+        self.test_results = test_results
         # assertions about the test calls
         current_test_dict = node_params
-        assert len(self.asserted_tests) > 0, "Unexpected test %s" % current_test_dict["shortname"]
+        shortname = current_test_dict["shortname"]
+        assert len(self.asserted_tests) > 0, "Unexpected test %s" % shortname
         expected_test_dict = self.asserted_tests.pop(0)
         for checked_key in expected_test_dict.keys():
-            assert checked_key in current_test_dict.keys(), "%s missing in %s" % (checked_key, current_test_dict["shortname"])
+            assert checked_key in current_test_dict.keys(), "%s missing in %s" % (checked_key, shortname)
             expected, current = expected_test_dict[checked_key], current_test_dict[checked_key]
             assert re.match(expected, current) is not None, "Expected parameter %s=%s "\
                                                             "but obtained %s=%s for %s" % (checked_key, expected,
                                                                                            checked_key, current,
                                                                                            expected_test_dict["shortname"])
 
+        self.add_test_result(shortname, "PASS")
         if self.fail_switch:
+            self.add_test_result(shortname, "FAIL")
             raise exceptions.TestFail("God wanted this test to fail")
+
+    def add_test_result(self, shortname, status):
+        name = mock.MagicMock()
+        name.name = shortname
+        self.test_results.append({
+            "name": name,
+            "status": status
+        })
 
 
 @contextlib.contextmanager
@@ -49,7 +61,10 @@ def new_job(config):
 
 
 def mock_run_test(_self, _job, factory, _queue, _set):
-    return DummyTestRunning(factory[1]['vt_params'])
+    if not hasattr(_self, "result"):
+        _self.result = mock.MagicMock()
+        _self.result.tests = []
+    return DummyTestRunning(factory[1]['vt_params'], _self.result.tests)
 
 
 @mock.patch('avocado_i2n.intertest_setup.new_job', new_job)


### PR DESCRIPTION
With two extra parameters it's possible to tell the runner to
retry a test N times.

The parameters are `retry_attempts` and `retry_stop`. The first is
the maximum number of retries, and the second indicates when to
stop retrying. The possible combinations of these values are:

- `retry_stop = error`: retry until error or a maximum of
                        `retry_attempts` number of times
- `retry_stop = success`: retry until success or a maximum of
                          `retry_attempts` number of times
- `retry_stop = none`: retry a maximum of `retry_attempts` number
                       of times

Only tests with the status of pass, warning, error or failure will
be retried. Other status will be ignored and the test will thus
run only once.