### PR TITLE
Provide proper dynamic classes in the VMNetwork constructor

### DIFF
--- a/avocado_i2n/vmnet/network.py
+++ b/avocado_i2n/vmnet/network.py
@@ -91,10 +91,14 @@ class VMNetwork(object):
         self.env = env
 
         # component types (could be replaced with extended ones)
-        self.new_node = VMNode
-        self.new_interface = VMInterface
-        self.new_netconfig = VMNetconfig
-        self.new_tunnel = VMTunnel
+        if getattr(self, "new_node", None) is None:
+            self.new_node = VMNode
+        if getattr(self, "new_interface", None) is None:
+            self.new_interface = VMInterface
+        if getattr(self, "new_netconfig", None) is None:
+            self.new_netconfig = VMNetconfig
+        if getattr(self, "new_tunnel", None) is None:
+            self.new_tunnel = VMTunnel
 
         # component instances
         self.nodes = {}


### PR DESCRIPTION
The vm network component types were not perfectly customizable and
needed some hacks like noop setters or simple enough classes in the
past in order to make this work. With the current cahnge we make
it easier for inheriting vm network classes to use their own
component types.

Thanks to Samir Aguiar for his final contribution to the plugin.