### PR TITLE
Pool backend extensions

### DIFF
--- a/avocado_i2n/cmd_parser.py
+++ b/avocado_i2n/cmd_parser.py
@@ -138,7 +138,6 @@ def params_from_cmd(config):
     # set default off and on state backends
     from .states import lvm, qcow2, lxc, btrfs, ramfile, pool, vmnet
     ss.BACKENDS = {"qcow2": qcow2.QCOW2Backend, "qcow2ext": qcow2.QCOW2ExtBackend,
-                   "pool": pool.QCOW2PoolBackend, "rootpool": pool.QCOW2RootPoolBackend,
                    "lvm": lvm.LVMBackend,
                    "lxc": lxc.LXCBackend, "btrfs": btrfs.BtrfsBackend,
                    "qcow2vt": qcow2.QCOW2VTBackend, "ramfile": ramfile.RamfileBackend,

--- a/avocado_i2n/states/pool.py
+++ b/avocado_i2n/states/pool.py
@@ -71,6 +71,23 @@ class TransferOps():
             return TransferOps.list_local(pool_path, params)
 
     @staticmethod
+    def compare(cache_path, pool_path, params):
+        """
+        Compare cache and pool external state version.
+
+        :param str cache_path: cache path to compare with
+        :param str pool_path: pool path to compare with
+        :param params: configuration parameters
+        :type params: {str, str}
+        """
+        if ":" in pool_path:
+            return TransferOps.compare_remote(cache_path, pool_path, params)
+        elif ";" in pool_path:
+            return TransferOps.compare_link(cache_path, pool_path, params)
+        else:
+            return TransferOps.compare_local(cache_path, pool_path, params)
+
+    @staticmethod
     def download(cache_path, pool_path, params):
         """
         Download a path from the pool depending on the pool location.
@@ -130,9 +147,9 @@ class TransferOps():
         return os.listdir(pool_path)
 
     @staticmethod
-    def download_local(cache_path, pool_path, params):
+    def compare_local(cache_path, pool_path, params):
         """
-        Download a path from the pool depending on the pool location.
+        Compare cache and pool external state version.
 
         All arguments are identical to the main entry method.
         """
@@ -140,13 +157,25 @@ class TransferOps():
             local_hash = crypto.hash_file(cache_path, 1048576, "md5")
         else:
             local_hash = ""
+        if os.path.exists(pool_path):
+            remote_hash = crypto.hash_file(pool_path, 1048576, "md5")
+        else:
+            remote_hash = ""
 
+        return local_hash == remote_hash
+
+    @staticmethod
+    def download_local(cache_path, pool_path, params):
+        """
+        Download a path from the pool depending on the pool location.
+
+        All arguments are identical to the main entry method.
+        """
         os.makedirs(os.path.dirname(cache_path), exist_ok=True)
 
         update_timeout = params.get_numeric("update_pool_timeout", 300)
         with image_lock(pool_path, update_timeout) as lock:
-            remote_hash = crypto.hash_file(pool_path, 1048576, "md5")
-            if local_hash == remote_hash:
+            if TransferOps.compare_local(cache_path, pool_path, params):
                 logging.info(f"Skip download of an already available {cache_path}")
                 return
             shutil.copy(pool_path, cache_path)
@@ -158,15 +187,9 @@ class TransferOps():
 
         All arguments are identical to the main entry method.
         """
-        if os.path.exists(cache_path):
-            local_hash = crypto.hash_file(cache_path, 1048576, "md5")
-        else:
-            local_hash = ""
-
         update_timeout = params.get_numeric("update_pool_timeout", 300)
         with image_lock(pool_path, update_timeout) as lock:
-            remote_hash = crypto.hash_file(pool_path, 1048576, "md5")
-            if local_hash == remote_hash:
+            if TransferOps.compare_local(cache_path, pool_path, params):
                 logging.info(f"Skip upload of an already available {cache_path}")
                 return
             os.makedirs(os.path.dirname(pool_path), exist_ok=True)
@@ -199,9 +222,9 @@ class TransferOps():
         return session.cmd_output(f"ls {path}").split()
 
     @staticmethod
-    def download_remote(cache_path, pool_path, params):
+    def compare_remote(cache_path, pool_path, params):
         """
-        Download a path from the pool depending on the pool location.
+        Compare cache and pool external state version.
 
         All arguments are identical to the main entry method.
         """
@@ -209,11 +232,6 @@ class TransferOps():
             local_hash = crypto.hash_file(cache_path, 1048576, "md5")
         else:
             local_hash = ""
-
-        os.makedirs(os.path.dirname(cache_path), exist_ok=True)
-
-        update_timeout = params.get_numeric("update_pool_timeout", 300)
-        # TODO: no support for remote lock files yet
         host, path = pool_path.split(":")
 
         session = remote.remote_login(params["nets_shell_client"],
@@ -223,18 +241,31 @@ class TransferOps():
                                       params["nets_shell_prompt"])
         remote_hash = ops.hash_file(session, path, "1M", "md5")
 
-        if local_hash == remote_hash:
-            logging.info(f"Skip download of an already available {cache_path} ({remote_hash})")
+        return local_hash == remote_hash
+
+    @staticmethod
+    def download_remote(cache_path, pool_path, params):
+        """
+        Download a path from the pool depending on the pool location.
+
+        All arguments are identical to the main entry method.
+        """
+        os.makedirs(os.path.dirname(cache_path), exist_ok=True)
+        # TODO: no support for remote lock files yet
+        host, path = pool_path.split(":")
+
+        if TransferOps.compare_remote(cache_path, pool_path, params):
+            logging.info(f"Skip download of an already available and valid {cache_path}")
             return
-        if local_hash is not None:
-            logging.info(f"Force download of an already available {cache_path} ({remote_hash})")
+        if os.path.exists(cache_path):
+            logging.info(f"Force download of an already available {cache_path}")
 
         remote.copy_files_from(host,
                                params["nets_file_transfer_client"],
                                params["nets_username"], params["nets_password"],
                                params["nets_file_transfer_port"],
                                path, cache_path,
-                               timeout=update_timeout)
+                               timeout=params.get_numeric("update_pool_timeout", 300))
 
     @staticmethod
     def upload_remote(cache_path, pool_path, params):
@@ -243,35 +274,21 @@ class TransferOps():
 
         All arguments are identical to the main entry method.
         """
-        if os.path.exists(cache_path):
-            local_hash = crypto.hash_file(cache_path, 1048576, "md5")
-        else:
-            local_hash = ""
-
-        update_timeout = params.get_numeric("update_pool_timeout", 300)
         # TODO: need to create remote directory if not available
         # TODO: no support for remote lock files yet
         host, path = pool_path.split(":")
 
-        session = remote.remote_login(params["nets_shell_client"],
-                                      host,
-                                      params["nets_shell_port"],
-                                      params["nets_username"], params["nets_password"],
-                                      params["nets_shell_prompt"])
-        remote_hash = ops.hash_file(session, path, "1M", "md5")
-
-        if local_hash == remote_hash:
-            logging.info(f"Skip upload of an already available {cache_path} ({remote_hash})")
+        if TransferOps.compare_remote(cache_path, pool_path, params):
+            logging.info(f"Skip upload of an already available {pool_path}")
             return
-        if local_hash is not None:
-            logging.info(f"Force upload of an already available {cache_path} ({remote_hash})")
+        logging.info(f"Will possibly force upload to {pool_path}")
 
         remote.copy_files_to(host,
                              params["nets_file_transfer_client"],
                              params["nets_username"], params["nets_password"],
                              params["nets_file_transfer_port"],
                              cache_path, path,
-                             timeout=update_timeout)
+                             timeout=params.get_numeric("update_pool_timeout", 300))
 
     @staticmethod
     def delete_remote(pool_path, params):
@@ -287,6 +304,15 @@ class TransferOps():
                                       params["nets_username"], params["nets_password"],
                                       params["nets_shell_prompt"])
         session.cmd(f"rm {path}")
+
+    @staticmethod
+    def compare_link(cache_path, pool_path, params):
+        """
+        Compare cache and pool external state version.
+
+        All arguments are identical to the main entry method.
+        """
+        return os.path.realpath(cache_path) == pool_path
 
     @staticmethod
     def list_link(pool_path, params):
@@ -308,7 +334,7 @@ class TransferOps():
 
         update_timeout = params.get_numeric("update_pool_timeout", 300)
         with image_lock(pool_path, update_timeout) as lock:
-            if os.path.realpath(cache_path) == pool_path:
+            if TransferOps.compare_link(cache_path, pool_path, params):
                 logging.info(f"Skip link of an already available {cache_path}")
                 return
             # actual data must be kept safe

--- a/avocado_i2n/states/pool.py
+++ b/avocado_i2n/states/pool.py
@@ -503,6 +503,41 @@ class QCOW2ImageTransfer(StateBackend):
         return os.path.basename(image_file.replace(".qcow2", ""))
 
     @classmethod
+    def compare_chain(cls, state, params):
+        """
+        Compare checksums for all dependencies states backing a given state.
+
+        :param str state: state name
+        :param params: configuration parameters
+        :type params: {str, str}
+        """
+        shared_pool = params["image_pool"]
+        cache_dir = params["vms_base_dir"]
+        vm_name = params["vms"]
+
+        next_state = state
+        while next_state != "":
+            for image_name in params.objects("images"):
+                image_params = params.object_params(image_name)
+                if next_state == image_params["image_name"]:
+                    cache_path = os.path.join(cache_dir, vm_name, next_state + ".qcow2")
+                    pool_path = os.path.join(shared_pool, vm_name, next_state + ".qcow2")
+                else:
+                    cache_path = os.path.join(cache_dir, vm_name, image_name, next_state + ".qcow2")
+                    pool_path = os.path.join(shared_pool, vm_name, image_name, next_state + ".qcow2")
+                if not cls.ops.compare(cache_path, pool_path, image_params):
+                    return False
+            if next_state == state and params["object_type"] in ["vms", "nets/vms"]:
+                cache_path = os.path.join(cache_dir, vm_name, next_state + ".state")
+                pool_path = os.path.join(shared_pool, vm_name, next_state + ".state")
+                if not cls.ops.compare(cache_path, pool_path, params):
+                    return False
+            # comparison of state chain is not yet complete if the state has backing dependencies
+            next_state = cls.get_dependency(next_state, params)
+
+        return True
+
+    @classmethod
     def _transfer_chain(cls, state, params, down=True):
         """
         Repeat pool operation an all dependencies states backing a given state.
@@ -530,7 +565,7 @@ class QCOW2ImageTransfer(StateBackend):
                 cache_path = os.path.join(cache_dir, vm_name, next_state + ".state")
                 pool_path = os.path.join(shared_pool, vm_name, next_state + ".state")
                 transfer_operation(cache_path, pool_path, params)
-            # download of state chain is not yet complete if the state has backing dependencies
+            # transfer of state chain is not yet complete if the state has backing dependencies
             next_state = cls.get_dependency(next_state, params)
 
     @classmethod
@@ -686,9 +721,12 @@ class RootSourcedStateBackend(StateBackend):
         target_image = cls.transport.get_image_path(params)
         if os.path.exists(target_image) and not params.get_boolean("update_pool", False):
             return False
-        elif not local_root_exists and shared_root_exists:
-            cls.transport.get_root(params, object)
-            return True
+        if shared_root_exists:
+            cache_valid = cls.transport.compare_chain(params["image_name"], params)
+            if not local_root_exists or not cache_valid:
+                cls.transport.get_root(params, object)
+                return True
+        return local_root_exists
 
     @classmethod
     def get_root(cls, params, object=None):
@@ -766,14 +804,14 @@ class SourcedStateBackend(StateBackend):
             return False
         elif not params.get_boolean("use_pool", True):
             return local_state_exists
-        elif local_state_exists:
-            return True
 
         pool_state_exists = cls.transport.check(params, object)
-        if pool_state_exists and not local_state_exists:
-            params["get_state"] = params["check_state"]
-            cls.transport.get(params, object)
-            return True
+        if pool_state_exists:
+            cache_valid = cls.transport.compare_chain(params["check_state"], params)
+            if not local_state_exists or not cache_valid:
+                params["get_state"] = params["check_state"]
+                cls.transport.get(params, object)
+                return True
         return local_state_exists
 
     @classmethod

--- a/avocado_i2n/states/pool.py
+++ b/avocado_i2n/states/pool.py
@@ -144,6 +144,8 @@ class TransferOps():
 
         All arguments are identical to the main entry method.
         """
+        if not os.path.exists(pool_path):
+            return []
         return os.listdir(pool_path)
 
     @staticmethod
@@ -219,7 +221,11 @@ class TransferOps():
                                       params["nets_shell_port"],
                                       params["nets_username"], params["nets_password"],
                                       params["nets_shell_prompt"])
-        return session.cmd_output(f"ls {path}").split()
+        status, output = session.cmd_status_output(f"ls {path}")
+        if status != 0:
+            logging.debug(f"Path {path} not found: {output}")
+            return []
+        return output.split()
 
     @staticmethod
     def compare_remote(cache_path, pool_path, params):

--- a/avocado_i2n/states/qcow2.py
+++ b/avocado_i2n/states/qcow2.py
@@ -28,7 +28,6 @@ INTERFACE
 """
 
 import os
-import json
 import re
 import shutil
 import logging as log
@@ -230,28 +229,6 @@ class QCOW2ExtBackend(SourcedStateBackend, QCOW2Backend):
     """Backend manipulating image states as external QCOW2 snapshots."""
 
     _require_running_object = False
-
-    @classmethod
-    def get_dependency(cls, state, params):
-        """
-        Return a backing state that the current state depends on.
-
-        :param str state: state name to retriee the backing dependency of
-
-        The rest of the arguments match the signature of the other methods here.
-        """
-        vm_name, image_name = params["vms"], params["images"]
-        vm_dir = os.path.join(params["vms_base_dir"], vm_name)
-        params["image_chain"] = f"snapshot {image_name}"
-        params["image_name_snapshot"] = os.path.join(image_name, state)
-        params["image_format_snapshot"] = "qcow2"
-        # TODO: we might want to return the complete backing chain but in some
-        # cases parts of it are stored in a remote location
-        #params["backing_chain"] = "yes"
-        qemu_img = QemuImg(params.object_params("snapshot"), vm_dir, "snapshot")
-        image_info = qemu_img.info(force_share=True, output="json")
-        image_file = json.loads(image_info).get("backing-filename", "")
-        return os.path.basename(image_file.replace(".qcow2", ""))
 
     @classmethod
     def _show(cls, params, object=None):

--- a/avocado_i2n/states/ramfile.py
+++ b/avocado_i2n/states/ramfile.py
@@ -43,17 +43,6 @@ class RamfileBackend(SourcedStateBackend):
     image_state_backend = None
 
     @classmethod
-    def get_dependency(cls, state, params):
-        """
-        Return a backing state that the current state depends on.
-
-        :param str state: state name to retriee the backing dependency of
-
-        The rest of the arguments match the signature of the other methods here.
-        """
-        return cls.image_state_backend.get_dependency(state, params)
-
-    @classmethod
     def _show(cls, params, object=None):
         """
         Return a list of available states of a specific type.

--- a/avocado_i2n/states/ramfile.py
+++ b/avocado_i2n/states/ramfile.py
@@ -34,10 +34,10 @@ logging = log.getLogger('avocado.test.' + __name__)
 from virttest import env_process
 from virttest.virt_vm import VMCreateError
 
-from .setup import StateBackend
+from .pool import SourcedStateBackend
 
 
-class RamfileBackend(StateBackend):
+class RamfileBackend(SourcedStateBackend):
     """Backend manipulating vm states as ram dump files."""
 
     image_state_backend = None
@@ -54,7 +54,7 @@ class RamfileBackend(StateBackend):
         return cls.image_state_backend.get_dependency(state, params)
 
     @classmethod
-    def show(cls, params, object=None):
+    def _show(cls, params, object=None):
         """
         Return a list of available states of a specific type.
 
@@ -89,7 +89,7 @@ class RamfileBackend(StateBackend):
         return states
 
     @classmethod
-    def check(cls, params, object=None):
+    def _check(cls, params, object=None):
         """
         Check whether a given state exists.
 
@@ -109,7 +109,7 @@ class RamfileBackend(StateBackend):
         return False
 
     @classmethod
-    def get(cls, params, object=None):
+    def _get(cls, params, object=None):
         """
         Retrieve a state disregarding the current changes.
 
@@ -131,7 +131,7 @@ class RamfileBackend(StateBackend):
         vm.resume(timeout=3)
 
     @classmethod
-    def set(cls, params, object=None):
+    def _set(cls, params, object=None):
         """
         Store a state saving the current changes.
 
@@ -158,7 +158,7 @@ class RamfileBackend(StateBackend):
         vm.resume(timeout=3)
 
     @classmethod
-    def unset(cls, params, object=None):
+    def _unset(cls, params, object=None):
         """
         Remove a state with previous changes.
 

--- a/avocado_i2n/states/setup.py
+++ b/avocado_i2n/states/setup.py
@@ -32,7 +32,6 @@ import logging as log
 logging = log.getLogger('avocado.test.' + __name__)
 
 from avocado.core import exceptions
-from virttest import env_process
 
 
 #: list of all available state backends and operations
@@ -121,24 +120,7 @@ class StateBackend():
         :returns: whether the object (root state) is exists
         :rtype: bool
         """
-        vm_name = params["vms"]
-        image_name = params["image_name"]
-        logging.debug("Checking whether %s's %s exists (root state requested)",
-                      vm_name, image_name)
-        if not os.path.isabs(image_name):
-            image_name = os.path.join(params["images_base_dir"], image_name)
-        image_format = params.get("image_format", "qcow2")
-        logging.debug("Checking for %s image %s", image_format, image_name)
-        image_format = "" if image_format in ["raw", ""] else "." + image_format
-        if object is not None and object.is_alive():
-            logging.info("The required virtual machine %s is alive and it shouldn't be", vm_name)
-            return False
-        if os.path.exists(image_name + image_format):
-            logging.info("The required virtual machine %s's %s exists", vm_name, image_name)
-            return True
-        else:
-            logging.info("The required virtual machine %s's %s doesn't exist", vm_name, image_name)
-            return False
+        raise NotImplementedError("Cannot use abstract state backend")
 
     @classmethod
     def get_root(cls, params, object=None):
@@ -162,19 +144,7 @@ class StateBackend():
         :param object: object whose states are manipulated
         :type object: :py:class:`virttest.qemu_vm.VM` or None
         """
-        vm_name = params["vms"]
-        if object is not None and object.is_alive():
-            object.destroy(gracefully=params.get_boolean("soft_boot", True))
-        image_name = params["image_name"]
-        if not os.path.isabs(image_name):
-            image_name = os.path.join(params["images_base_dir"], image_name)
-        image_format = params.get("image_format")
-        image_format = "" if image_format in ["raw", ""] else "." + image_format
-        if not os.path.exists(image_name + image_format):
-            os.makedirs(os.path.dirname(image_name), exist_ok=True)
-            logging.info("Creating image %s for %s", image_name, vm_name)
-            params.update({"create_image": "yes", "force_create_image": "yes"})
-            env_process.preprocess_image(None, params, image_name)
+        raise NotImplementedError("Cannot use abstract state backend")
 
     @classmethod
     def unset_root(cls, params, object=None):
@@ -186,19 +156,7 @@ class StateBackend():
         :param object: object whose states are manipulated
         :type object: :py:class:`virttest.qemu_vm.VM` or None
         """
-        vm_name = params["vms"]
-        if object is not None and object.is_alive():
-            object.destroy(gracefully=params.get_boolean("soft_boot", True))
-        image_name = params["image_name"]
-        if not os.path.isabs(image_name):
-            image_name = os.path.join(params["images_base_dir"], image_name)
-        logging.info("Removing image %s for %s", image_name, vm_name)
-        params.update({"remove_image": "yes"})
-        env_process.postprocess_image(None, params, image_name)
-        try:
-            os.rmdir(os.path.dirname(image_name))
-        except OSError as error:
-            logging.debug("Image directory not yet empty: %s", error)
+        raise NotImplementedError("Cannot use abstract state backend")
 
 
 #: available state backend implementations

--- a/avocado_i2n/states/setup.py
+++ b/avocado_i2n/states/setup.py
@@ -288,6 +288,7 @@ def check_states(run_params, env=None):
 
         # if the snapshot is not defined skip (leaf tests that are no setup)
         if not state_params.get("check_state"):
+            logging.debug(f"Skip checking any {params_obj_type} state for {params_obj_name}")
             continue
         else:
             state = state_params["check_state"]
@@ -364,6 +365,7 @@ def get_states(run_params, env=None):
 
         # if the state is not defined skip (leaf tests that are no setup)
         if not state_params.get("get_state"):
+            logging.debug(f"Skip getting any {params_obj_type} state for {params_obj_name}")
             continue
         else:
             state = state_params["get_state"]
@@ -433,6 +435,7 @@ def set_states(run_params, env=None):
 
         # if the state is not defined skip (leaf tests that are no setup)
         if not state_params.get("set_state"):
+            logging.debug(f"Skip setting any {params_obj_type} state for {params_obj_name}")
             continue
         else:
             state = state_params["set_state"]
@@ -508,6 +511,7 @@ def unset_states(run_params, env=None):
 
         # if the state is not defined skip (leaf tests that are no setup)
         if not state_params.get("unset_state"):
+            logging.debug(f"Skip unsetting any {params_obj_type} state for {params_obj_name}")
             continue
         else:
             state = state_params["unset_state"]

--- a/tp_folder/configs/guest-base.cfg
+++ b/tp_folder/configs/guest-base.cfg
@@ -370,8 +370,8 @@ get_state = 0root
 nets = net1
 states_chain = nets vms images
 states_nets = vmnet
-states_images = pool
-states_vms = pool
+states_images = qcow2ext
+states_vms = ramfile
 # Parameters for the pool state backend
 image_pool = /mnt/local/pool
 # Parameters for the LVM state backend

--- a/tp_folder/controls/pre_state.control
+++ b/tp_folder/controls/pre_state.control
@@ -22,7 +22,6 @@ logging.info("%s control file.", NAME)
 
 logging.info(f"Adding default state backends")
 ss.BACKENDS = {"qcow2": qcow2.QCOW2Backend, "qcow2ext": qcow2.QCOW2ExtBackend,
-               "pool": pool.QCOW2PoolBackend, "rootpool": pool.QCOW2RootPoolBackend,
                "lvm": lvm.LVMBackend,
                "lxc": lxc.LXCBackend, "btrfs": btrfs.BtrfsBackend,
                "qcow2vt": qcow2.QCOW2VTBackend, "ramfile": ramfile.RamfileBackend,

--- a/tp_folder/controls/pre_test.control
+++ b/tp_folder/controls/pre_test.control
@@ -53,7 +53,6 @@ env_process.postprocess_vm_on_hook = on_state(ss.set_states)
 env_process.postprocess_vm_off_hook = off_state(ss.set_states)
 logging.info(f"Adding default state backends")
 ss.BACKENDS = {"qcow2": qcow2.QCOW2Backend, "qcow2ext": qcow2.QCOW2ExtBackend,
-               "pool": pool.QCOW2PoolBackend, "rootpool": pool.QCOW2RootPoolBackend,
                "lvm": lvm.LVMBackend,
                "lxc": lxc.LXCBackend, "btrfs": btrfs.BtrfsBackend,
                "qcow2vt": qcow2.QCOW2VTBackend, "ramfile": ramfile.RamfileBackend,


### PR DESCRIPTION
The following branch uses test-driven development and core-boundary
separation of isolation-integration test contracts to refactor the
previous pool state backends as pool extensions of the other (now
actual) state backends and adds further state transfer capabilities.